### PR TITLE
Update token voting repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/aragon/multisig-plugin
 [submodule "lib/token-voting-plugin"]
 	path = lib/token-voting-plugin
-	url = https://github.com/aragon/token-voting-plugin
+	url = https://github.com/aragon/token-voting-plugin-hardhat
 [submodule "lib/staged-proposal-processor-plugin"]
 	path = lib/staged-proposal-processor-plugin
 	url = https://github.com/aragon/staged-proposal-processor-plugin


### PR DESCRIPTION
 This PR updates the Git submidule URL of the token voting plugin, which is now https://github.com/aragon/token-voting-plugin-hardhat

There are no source code changes visible, the only difference is the remote's URL