### PR TITLE
Allow for multiple ignored .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ lcov.info
 report
 
 # Settings
-.env
+!.env.example
+.env*
 multisig-members.json
 
 # Other


### PR DESCRIPTION
- Keep track of `.env.example`
- Ignore `.env` followed by anything else