### PR TITLE
Deeper deployment transaction code split

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ TokenVotingSetup tokenVotingSetup = new TokenVotingSetup(
     ),
     new GovernanceWrappedERC20(IERC20Upgradeable(address(0)), "", "")
 );
-StagedProposalProcessorSetup stagedProposalProcessorSetup = new StagedProposalProcessorSetup();
+StagedProposalProcessorSetup stagedProposalProcessorSetup = new StagedProposalProcessorSetup(new SPP());
 
 // Parameters
 ProtocolFactory.DeploymentParameters memory params = ProtocolFactory.DeploymentParameters({

--- a/docs/modules/ROOT/pages/osx-local-testing.adoc
+++ b/docs/modules/ROOT/pages/osx-local-testing.adoc
@@ -111,7 +111,7 @@ TokenVotingSetup tokenVotingSetup = new TokenVotingSetup(
     ),
     new GovernanceWrappedERC20(IERC20Upgradeable(address(0)), "", "")
 );
-StagedProposalProcessorSetup stagedProposalProcessorSetup = new StagedProposalProcessorSetup();
+StagedProposalProcessorSetup stagedProposalProcessorSetup = new StagedProposalProcessorSetup(new SPP());
 
 // Parameters
 ProtocolFactory.DeploymentParameters memory params = ProtocolFactory.DeploymentParameters({

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -20,6 +20,7 @@ import {TokenVotingSetup} from "@aragon/token-voting-plugin/TokenVotingSetup.sol
 import {GovernanceERC20} from "@aragon/token-voting-plugin/erc20/GovernanceERC20.sol";
 import {GovernanceWrappedERC20} from "@aragon/token-voting-plugin/erc20/GovernanceWrappedERC20.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {StagedProposalProcessor as SPP} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessor.sol";
 import {StagedProposalProcessorSetup} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessorSetup.sol";
 
 import {ProtocolFactory} from "../src/ProtocolFactory.sol";
@@ -171,7 +172,7 @@ contract DeployScript is Script {
     }
 
     function deployStagedProposalProcessorSetup() internal {
-        stagedProposalProcessorSetup = new StagedProposalProcessorSetup();
+        stagedProposalProcessorSetup = new StagedProposalProcessorSetup(new SPP());
         vm.label(address(stagedProposalProcessorSetup), "StagedProposalProcessorSetup");
     }
 

--- a/script/TestUpgrade.s.sol
+++ b/script/TestUpgrade.s.sol
@@ -31,6 +31,7 @@ import {TokenVotingSetup} from "@aragon/token-voting-plugin/TokenVotingSetup.sol
 import {GovernanceERC20} from "@aragon/token-voting-plugin/erc20/GovernanceERC20.sol";
 import {GovernanceWrappedERC20} from "@aragon/token-voting-plugin/erc20/GovernanceWrappedERC20.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {StagedProposalProcessor as SPP} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessor.sol";
 import {StagedProposalProcessorSetup} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessorSetup.sol";
 
 import {ProtocolFactory} from "../src/ProtocolFactory.sol";
@@ -128,7 +129,7 @@ contract TestUpgradeScript is Script {
                 )
             )
         });
-        address newSppSetup = address(new StagedProposalProcessorSetup());
+        address newSppSetup = address(new StagedProposalProcessorSetup(new SPP()));
         actions[3] = Action({
             to: address(sppRepo),
             value: 0,

--- a/src/ProtocolFactory.sol
+++ b/src/ProtocolFactory.sol
@@ -127,6 +127,8 @@ contract ProtocolFactory {
         NotStarted,
         Phase1Complete,
         Phase2Complete,
+        Phase3Complete,
+        Phase4Complete,
         Complete
     }
 
@@ -161,35 +163,54 @@ contract ProtocolFactory {
             _deployPhase2();
         } else if (currentPhase == DeploymentPhase.Phase2Complete) {
             _deployPhase3();
+        } else if (currentPhase == DeploymentPhase.Phase3Complete) {
+            _deployPhase4();
+        } else if (currentPhase == DeploymentPhase.Phase4Complete) {
+            _deployPhase5();
         }
         // else: already complete, nop
 
         return currentPhase == DeploymentPhase.Complete;
     }
 
-    /// @dev Phase 1: Create Management DAO and deploy ENS infrastructure (~1.9M gas)
+    /// @dev Phase 1: Create Management DAO and deploy ENS infrastructure
     function _deployPhase1() internal {
         // Create the DAO that will own the registries and the core plugin repo's
         prepareRawManagementDao();
-
-        // Set up the ENS registry and the requested domains
-        prepareEnsRegistry();
 
         currentPhase = DeploymentPhase.Phase1Complete;
         emit PhaseCompleted(currentPhase);
     }
 
-    /// @dev Phase 2: Deploy OSx core contracts (~4.5M gas)
+    /// @dev Phase 2: Create Management DAO and deploy ENS infrastructure
     function _deployPhase2() internal {
-        // Deploy the OSx core contracts
-        prepareOSx();
+        // Set up the ENS registry and the requested domains
+        prepareEnsRegistry();
 
         currentPhase = DeploymentPhase.Phase2Complete;
         emit PhaseCompleted(currentPhase);
     }
 
-    /// @dev Phase 3: Set up permissions, deploy plugin repos and finalize Management DAO (~7.9M gas)
+    /// @dev Phase 3: Deploy OSx core contracts
     function _deployPhase3() internal {
+        // Deploy the OSx core contracts
+        prepareOSx();
+
+        currentPhase = DeploymentPhase.Phase3Complete;
+        emit PhaseCompleted(currentPhase);
+    }
+
+    /// @dev Phase 4: Deploy OSx factories
+    function _deployPhase4() internal {
+        // Deploy OSx factories
+        prepareOSxFactories();
+
+        currentPhase = DeploymentPhase.Phase4Complete;
+        emit PhaseCompleted(currentPhase);
+    }
+
+    /// @dev Phase 5: Set up permissions, deploy plugin repos and finalize Management DAO
+    function _deployPhase5() internal {
         preparePermissions();
 
         // Prepare the plugin repo's and their versions
@@ -326,20 +347,26 @@ contract ProtocolFactory {
             )
         );
 
+        // Store the plain implementation addresses
+
+        deployment.globalExecutor = parameters.osxImplementations.globalExecutor;
+        deployment.placeholderSetup = parameters.osxImplementations.placeholderSetup;
+
         // Static contract deployments
         /// @dev Offloaded to separate factories to avoid hitting code size limits.
 
         deployment.pluginSetupProcessor =
             parameters.helperFactories.pspHelper.deployStatic(deployment.pluginRepoRegistry);
+    }
+
+    function prepareOSxFactories() internal {
+        // Static contract deployments
+        /// @dev Offloaded to separate factories to avoid hitting code size limits.
+
         deployment.daoFactory =
             parameters.helperFactories.daoHelper.deployFactory(deployment.daoRegistry, deployment.pluginSetupProcessor);
         deployment.pluginRepoFactory =
             parameters.helperFactories.pluginRepoHelper.deployFactory(deployment.pluginRepoRegistry);
-
-        // Store the plain implementation addresses
-
-        deployment.globalExecutor = parameters.osxImplementations.globalExecutor;
-        deployment.placeholderSetup = parameters.osxImplementations.placeholderSetup;
     }
 
     function preparePermissions() internal {

--- a/src/ProtocolFactory.sol
+++ b/src/ProtocolFactory.sol
@@ -154,7 +154,7 @@ contract ProtocolFactory {
     }
 
     /// @notice Executes the next deployment phase. Call repeatedly until deployment is complete.
-    /// @dev Due to EIP-7825 gas limits, deployment is split into 3 phases.
+    /// @dev Due to EIP-7825 gas limits, deployment is split into 5 phases.
     /// @return complete True if deployment is complete, false if more phases remain.
     function deployPhase() external returns (bool complete) {
         if (currentPhase == DeploymentPhase.NotStarted) {
@@ -182,7 +182,7 @@ contract ProtocolFactory {
         emit PhaseCompleted(currentPhase);
     }
 
-    /// @dev Phase 2: Create Management DAO and deploy ENS infrastructure
+    /// @dev Phase 2: Deploy ENS infrastructure since Management DAO is created in Phase 1
     function _deployPhase2() internal {
         // Set up the ENS registry and the requested domains
         prepareEnsRegistry();

--- a/test/ProtocolFactory.t.sol
+++ b/test/ProtocolFactory.t.sol
@@ -39,7 +39,10 @@ import {Multisig} from "@aragon/multisig-plugin/Multisig.sol";
 import {TokenVoting} from "@aragon/token-voting-plugin/TokenVoting.sol";
 import {MajorityVotingBase} from "@aragon/token-voting-plugin/base/MajorityVotingBase.sol";
 import {IMajorityVoting} from "@aragon/token-voting-plugin/base/IMajorityVoting.sol";
-import {StagedProposalProcessor} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessor.sol";
+import {
+    StagedProposalProcessor,
+    StagedProposalProcessor as SPP
+} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessor.sol";
 import {RuledCondition} from "@aragon/osx-commons-contracts/src/permission/condition/extensions/RuledCondition.sol";
 
 import {AdminSetup} from "@aragon/admin-plugin/AdminSetup.sol";
@@ -1968,7 +1971,7 @@ contract ProtocolFactoryTest is AragonTest {
                 )
             )
         });
-        address newSppSetup = address(new StagedProposalProcessorSetup());
+        address newSppSetup = address(new StagedProposalProcessorSetup(new SPP()));
         actions[3] = Action({
             to: deployment.stagedProposalProcessorPluginRepo,
             value: 0,

--- a/test/ProtocolFactory.t.sol
+++ b/test/ProtocolFactory.t.sol
@@ -145,10 +145,12 @@ contract ProtocolFactoryTest is AragonTest {
         // It Should emit an event with the factory address on final phase
         factory.deployPhase(); // Phase 1
         factory.deployPhase(); // Phase 2
+        factory.deployPhase(); // Phase 3
+        factory.deployPhase(); // Phase 4
 
         vm.expectEmit(true, true, true, true);
         emit ProtocolFactory.ProtocolDeployed(factory);
-        factory.deployPhase(); // Phase 3
+        factory.deployPhase(); // Phase 5
 
         // It The deployment addresses are filled with the new contracts
         deployment = factory.getDeployment();
@@ -274,11 +276,13 @@ contract ProtocolFactoryTest is AragonTest {
         builder.withManagementDaoMembers(mgmtDaoMembers).withManagementDaoMinApprovals(2);
         factory = builder.build();
 
-        // Phase 1 and 2 succeed
+        // Phases 1-4 succeed
+        factory.deployPhase();
+        factory.deployPhase();
         factory.deployPhase();
         factory.deployPhase();
 
-        // Fail on phase 3 (when concludeManagementDao is called)
+        // Fail on phase 5 (when concludeManagementDao is called)
         vm.expectRevert(ProtocolFactory.MemberListIsTooSmall.selector);
         factory.deployPhase();
 
@@ -308,7 +312,15 @@ contract ProtocolFactoryTest is AragonTest {
         factory.deployPhase();
         assertEq(uint256(factory.currentPhase()), uint256(ProtocolFactory.DeploymentPhase.Phase2Complete));
 
-        // Deploy phase 3 - expect event
+        // Deploy phase 3
+        factory.deployPhase();
+        assertEq(uint256(factory.currentPhase()), uint256(ProtocolFactory.DeploymentPhase.Phase3Complete));
+
+        // Deploy phase 4
+        factory.deployPhase();
+        assertEq(uint256(factory.currentPhase()), uint256(ProtocolFactory.DeploymentPhase.Phase4Complete));
+
+        // Deploy phase 5 - expect event
         vm.expectEmit(true, true, true, true);
         emit ProtocolFactory.ProtocolDeployed(factory);
         factory.deployPhase();

--- a/test/helpers/ProtocolFactoryBuilder.sol
+++ b/test/helpers/ProtocolFactoryBuilder.sol
@@ -23,6 +23,7 @@ import {TokenVotingSetup} from "@aragon/token-voting-plugin/TokenVotingSetup.sol
 import {GovernanceERC20} from "@aragon/token-voting-plugin/erc20/GovernanceERC20.sol";
 import {GovernanceWrappedERC20} from "@aragon/token-voting-plugin/erc20/GovernanceWrappedERC20.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {StagedProposalProcessor as SPP} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessor.sol";
 import {StagedProposalProcessorSetup} from "@aragon/staged-proposal-processor-plugin/StagedProposalProcessorSetup.sol";
 
 import {ALICE_ADDRESS, RANDOM_ADDRESS} from "../constants.sol";
@@ -51,7 +52,7 @@ contract ProtocolFactoryBuilder is Test {
         ),
         new GovernanceWrappedERC20(IERC20Upgradeable(address(0)), "", "")
     );
-    StagedProposalProcessorSetup SPP_SETUP = new StagedProposalProcessorSetup();
+    StagedProposalProcessorSetup SPP_SETUP = new StagedProposalProcessorSetup(new SPP());
 
     string daoRootDomain = "dao-test";
     string managementDaoSubdomain = "management-test";


### PR DESCRIPTION
Only after #24 

The current deployment function exceeds the block code size of certain networks. In order for the factory to work, we need to:
- Use a lightener version of the SPP
- Split up the `deployPhase()` inner calls
